### PR TITLE
fix arch observer bug

### DIFF
--- a/src/model.py
+++ b/src/model.py
@@ -203,9 +203,9 @@ class X86UnicornModel(Model):
         taints = []
         for input_ in inputs:
             # self.LOG.dbg_model_header(input_) # Backported; Should be input_id!
-            self.reset_model()
             try:
                 self._load_input(input_)
+                self.reset_model()
                 
                 if LOGGER.model_debug:
                     # address = 0x1ffc + self.sandbox_base # 0x000 - 0x1000 is first page


### PR DESCRIPTION
The ARCH observer had a small bug in which it exposes the final register state of the previous trace, rather than the initial register state of the current trace. This is due to the fact that the method `self.reset_model()` is called before the input is loaded (`self._load_input(input_)`).

This patch just transposes the two to fix the bug.