### PR TITLE
raise ConfigExceptions rather than ignoring them

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -316,20 +316,20 @@ class ConfCls:
         }
 
         if name[0] == "_":
-            ConfigException(f"Attempting to set an internal configuration variable {name}.")
+            raise ConfigException(f"Attempting to set an internal configuration variable {name}.")
         if getattr(self, name, None) is None:
-            ConfigException(f"Unknown configuration variable {name}.\n"
-                            f"It's likely a typo in the configuration file.")
+            raise ConfigException(f"Unknown configuration variable {name}.\n"
+                                  f"It's likely a typo in the configuration file.")
         if type(self.__getattribute__(name)) != type(value):
-            ConfigException(f"Wrong type of the configuration variable {name}.\n"
-                            f"It's likely a typo in the configuration file.")
+            raise ConfigException(f"Wrong type of the configuration variable {name}.\n"
+                                  f"It's likely a typo in the configuration file.")
 
         # value checks
         if options.get(name, '') != '' and value not in options[name]:
-            ConfigException(f"Unknown value '{value}' of configuration variable '{name}'")
+            raise ConfigException(f"Unknown value '{value}' of configuration variable '{name}'")
         if (self.input_main_region_size % 4096 != 0) or \
                 (self.input_assist_region_size % 4096 != 0):
-            ConfigException("Inputs must be page-aligned")
+            raise ConfigException("Inputs must be page-aligned")
 
         # special handling
         if name == "extended_instruction_blocklist":

--- a/src/coverage.py
+++ b/src/coverage.py
@@ -285,5 +285,4 @@ def get_coverage(instruction_set: InstructionSet, executor: Executor, model: Mod
     elif CONF.coverage_type == 'none':
         return NoCoverage(instruction_set, executor, model, analyser)
     else:
-        ConfigException("unknown value of `coverage_type` configuration option")
-        exit(1)
+        raise ConfigException("unknown value of `coverage_type` configuration option")

--- a/src/executor.py
+++ b/src/executor.py
@@ -1178,6 +1178,6 @@ def get_executor() -> Executor:
         'x86-gem5': X86Gem5
     }
     if CONF.executor not in options:
-        ConfigException("unknown executor in config.py")
+        raise ConfigException("unknown executor in config.py")
     return options[CONF.executor]()
 

--- a/src/generator.py
+++ b/src/generator.py
@@ -1273,5 +1273,4 @@ def get_generator(instruction_set: InstructionSet) -> Generator:
         if CONF.generator == 'random':
             return X86RandomGenerator(instruction_set)
 
-    ConfigException("unknown value of `instruction_set` configuration option")
-    exit(1)
+    raise ConfigException("unknown value of `instruction_set` configuration option")

--- a/src/input_generator.py
+++ b/src/input_generator.py
@@ -98,6 +98,5 @@ def get_input_generator() -> InputGenerator:
         'random': RandomInputGenerator,
     }
     if CONF.input_generator not in options:
-        ConfigException("unknown input_generator in config.py")
-        exit(1)
+        raise ConfigException("unknown input_generator in config.py")
     return options[CONF.input_generator]()

--- a/src/model.py
+++ b/src/model.py
@@ -1044,8 +1044,7 @@ def get_model(bases: Tuple[int, int]) -> Model:
         elif "seq" in CONF.contract_execution_clause:
             model = X86UnicornSeq(bases[0], bases[1])
         else:
-            ConfigException("unknown value of `contract_execution_clause` configuration option")
-            exit(1)
+            raise ConfigException("unknown value of `contract_execution_clause` configuration option")
 
         # observational part of the contract
         if CONF.contract_observation_clause == "l1d":
@@ -1063,10 +1062,8 @@ def get_model(bases: Tuple[int, int]) -> Model:
         elif CONF.contract_observation_clause == 'arch':
             model.tracer = ArchTracer()
         else:
-            ConfigException("unknown value of `contract_observation_clause` configuration option")
-            exit(1)
+            raise ConfigException("unknown value of `contract_observation_clause` configuration option")
 
         return model
     else:
-        ConfigException("unknown value of `model` configuration option")
-        exit(1)
+        raise ConfigException("unknown value of `model` configuration option")


### PR DESCRIPTION
It appears almost all ConfigExceptions were instantiated but never raised, allowing execution to improperly continue. This patch raises these ConfigExceptions.